### PR TITLE
Include VERSION in release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -97,7 +97,7 @@ defmodule ColonelKurtz.MixProject do
         "GitHub" => "https://github.com/vigetlabs/colonel_kurtz_ex",
         "Docs" => "http://code.viget.com/colonel_kurtz_ex/readme.html"
       },
-      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*)
+      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG* VERSION*)
     ]
   end
 end


### PR DESCRIPTION
0.1 doesn't run because VERSION is not included in the release. 

![Screen Shot 2020-05-14 at 1 54 19 PM](https://user-images.githubusercontent.com/800803/81968549-88e7cd00-95ea-11ea-95cb-b0ef36a58838.png)
