### PR TITLE
[fix] Properly handle converting params to string keys (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## New Changes
 
-* Added typespecs
-* Added credo
-* Added dialyxir
-* Added test configuration and a foundation for further test coverage
+* [Bugfix #10](https://github.com/vigetlabs/colonel_kurtz_ex/issues/10): properly convert param keys to strings
 
 ---
 

--- a/lib/colonel_kurtz/block_type.ex
+++ b/lib/colonel_kurtz/block_type.ex
@@ -123,14 +123,16 @@ defmodule ColonelKurtz.BlockType do
   def lift_content_errors(changeset), do: changeset
 
   #
-  # Extracts the Block's Content attributes from params, converting string keys
-  # to atoms. Will only contain the keys specified in the schema (Defined by
-  # using the `defattributes/1` macro).
+  # Extracts the Block's Content attributes from params, converting atom keys
+  # to strings.
   #
   @spec attributes_from_params(map) :: map
   def attributes_from_params(params) do
     Enum.reduce(Map.keys(params), %{}, fn key, acc ->
-      Map.put(acc, key, Map.get(params, Atom.to_string(key), Map.get(params, key)))
+      Map.put(acc, convert_key(key), Map.get(params, key))
     end)
   end
+
+  defp convert_key(key) when is_binary(key), do: key
+  defp convert_key(key) when is_atom(key), do: Atom.to_string(key)
 end

--- a/lib/colonel_kurtz/block_type_content.ex
+++ b/lib/colonel_kurtz/block_type_content.ex
@@ -62,7 +62,7 @@ defmodule ColonelKurtz.BlockTypeContent do
         struct_attrs =
           for name <- __schema__(:fields),
               into: Keyword.new(),
-              do: {name, Map.get(attrs, name)}
+              do: {name, Map.get(attrs, Atom.to_string(name))}
 
         struct!(__MODULE__, struct_attrs)
       end

--- a/test/block_type_test.exs
+++ b/test/block_type_test.exs
@@ -37,4 +37,23 @@ defmodule ColonelKurtzTest.BlockTypeTest do
                ColonelKurtz.Renderer.render_blocks(blocks)
     end
   end
+
+  describe "#attributes_from_params/1" do
+    # https://github.com/vigetlabs/colonel_kurtz_ex/issues/10
+    test "returns a map with string keys when given a map with string keys" do
+      params = %{"src" => "imagesrc.png"}
+      assert %{"src" => "imagesrc.png"} = ColonelKurtz.BlockType.attributes_from_params(params)
+    end
+
+    test "returns a map with string keys when given a map with atom keys" do
+      params = %{src: "imagesrc.png"}
+      assert %{"src" => "imagesrc.png"} = ColonelKurtz.BlockType.attributes_from_params(params)
+    end
+
+    test "returns a map with string keys when given a map with mixed keys" do
+      params = %{"src" => "imagesrc.png", other_prop: "other_value"}
+      assert %{"src" => "imagesrc.png", "other_prop" => "other_value"} = ColonelKurtz.BlockType.attributes_from_params(params)
+    end
+
+  end
 end


### PR DESCRIPTION
Resolves #10 

Fixes a bug that was blowing up the sample phoenix project preventing any CK block changes from saving.