### PR TITLE
Allow blank content module

### DIFF
--- a/lib/colonel_kurtz/block_type.ex
+++ b/lib/colonel_kurtz/block_type.ex
@@ -27,144 +27,15 @@ defmodule ColonelKurtz.BlockType do
   The BlockType __using__ macro allows modules to behave as BlockTypes.
   """
   defmacro __using__(args \\ []) do
-    if Keyword.get(args, :content, true) do
-      quote do
-        use Ecto.Schema
-
-        import ColonelKurtz.Validation, only: [validate_blocks: 3]
-        import Ecto.Changeset
-        import ColonelKurtz.BlockType
-
-        alias ColonelKurtz.Block
-        alias ColonelKurtz.BlockType
-        alias ColonelKurtz.CKBlocks
-        alias ColonelKurtz.EctoHelpers
-
-        @typep changeset :: Ecto.Changeset.t()
-        @typep block :: block
-        @typep block_struct :: BlockType.t()
-
-        @block_attributes [:block_id, :type, :content, :blocks]
-
-        @content_module Module.concat(__MODULE__, Content)
-
-        @primary_key {:block_id, :binary_id, autogenerate: false}
-
-        @derive {Jason.Encoder, only: @block_attributes}
-
-        embedded_schema do
-          field(:type, :string, null: false)
-          field(:blocks, CKBlocks)
-          embeds_one(:content, @content_module)
-        end
-
-        @doc """
-        Given a named BlockType struct and a map of params, creates a changeset
-        and runs validations for the BlockType and BlockType.Content.
-
-        Returns %Ecto.Changeset{}.
-        """
-        @spec changeset(block_struct, map) :: changeset
-        def changeset(block, params) do
-          changeset =
-            struct(__MODULE__)
-            |> cast(params, [:block_id, :type, :blocks])
-            |> cast_embed(:content)
-            |> lift_content_errors()
-            |> validate_blocks(:blocks, is_block: true)
-
-          validate(block, changeset)
-        end
-
-        @spec validate(block_struct, changeset) :: changeset
-        def validate(_block, changeset), do: changeset
-        defoverridable validate: 2
-
-        @doc """
-        Takes a Block map and converts it to a named BlockType struct according
-        to its :type. Generates a :block_id if necessary, and turns `block.content`
-        into a named BlockType.Content module as well.
-        """
-        @spec from_map(block) :: block_struct
-        def from_map(%{type: type, content: content, blocks: blocks} = attrs) do
-          content =
-            content
-            |> attributes_from_params()
-            |> @content_module.from_map()
-
-          struct!(__MODULE__,
-            block_id: Map.get(attrs, :block_id) || Ecto.UUID.generate(),
-            type: type,
-            content: content,
-            blocks: blocks || []
-          )
-        end
-      end
+    if content_schema_defined(args) do
+      Code.eval_file("lib/colonel_kurtz/block_type/with_content.ex")
     else
-      quote do
-        use Ecto.Schema
-
-        import ColonelKurtz.Validation, only: [validate_blocks: 3]
-        import Ecto.Changeset
-        import ColonelKurtz.BlockType
-
-        alias ColonelKurtz.Block
-        alias ColonelKurtz.BlockType
-        alias ColonelKurtz.CKBlocks
-        alias ColonelKurtz.EctoHelpers
-
-        @typep changeset :: Ecto.Changeset.t()
-        @typep block :: block
-        @typep block_struct :: BlockType.t()
-
-        @block_attributes [:block_id, :type, :content, :blocks]
-
-        @primary_key {:block_id, :binary_id, autogenerate: false}
-
-        @derive {Jason.Encoder, only: @block_attributes}
-
-        embedded_schema do
-          field(:type, :string, null: false)
-          field(:blocks, CKBlocks)
-          field(:content, :map)
-        end
-
-        @doc """
-        Given a named BlockType struct and a map of params, creates a changeset
-        and runs validations for the BlockType and BlockType.Content.
-
-        Returns %Ecto.Changeset{}.
-        """
-        @spec changeset(block_struct, map) :: changeset
-        def changeset(block, params) do
-          changeset =
-            struct(__MODULE__)
-            |> cast(params, [:block_id, :type, :blocks, :content])
-            |> validate_blocks(:blocks, is_block: true)
-
-          validate(block, changeset)
-        end
-
-        @spec validate(block_struct, changeset) :: changeset
-        def validate(_block, changeset), do: changeset
-        defoverridable validate: 2
-
-        @doc """
-        Takes a Block map and converts it to a named BlockType struct according
-        to its :type. Generates a :block_id if necessary, and turns `block.content`
-        into a named BlockType.Content module as well.
-        """
-        @spec from_map(block) :: block_struct
-        def from_map(%{type: type, content: content, blocks: blocks} = attrs) do
-          struct!(__MODULE__,
-            block_id: Map.get(attrs, :block_id) || Ecto.UUID.generate(),
-            type: type,
-            content: attributes_from_params(content),
-            blocks: blocks || []
-          )
-        end
-      end
+      Code.eval_file("lib/colonel_kurtz/block_type/without_content.ex")
     end
+  end
+
+  defp content_schema_defined(args) do
+    Keyword.get(args, :content, true)
   end
 
   #

--- a/lib/colonel_kurtz/block_type.ex
+++ b/lib/colonel_kurtz/block_type.ex
@@ -26,77 +26,143 @@ defmodule ColonelKurtz.BlockType do
   @doc """
   The BlockType __using__ macro allows modules to behave as BlockTypes.
   """
-  defmacro __using__(_opts) do
-    quote do
-      use Ecto.Schema
+  defmacro __using__(args \\ []) do
+    if Keyword.get(args, :content, true) do
+      quote do
+        use Ecto.Schema
 
-      import ColonelKurtz.Validation, only: [validate_blocks: 3]
-      import Ecto.Changeset
-      import ColonelKurtz.BlockType
+        import ColonelKurtz.Validation, only: [validate_blocks: 3]
+        import Ecto.Changeset
+        import ColonelKurtz.BlockType
 
-      alias ColonelKurtz.Block
-      alias ColonelKurtz.BlockType
-      alias ColonelKurtz.CKBlocks
-      alias ColonelKurtz.EctoHelpers
+        alias ColonelKurtz.Block
+        alias ColonelKurtz.BlockType
+        alias ColonelKurtz.CKBlocks
+        alias ColonelKurtz.EctoHelpers
 
-      @typep changeset :: Ecto.Changeset.t()
-      @typep block :: block
-      @typep block_struct :: BlockType.t()
+        @typep changeset :: Ecto.Changeset.t()
+        @typep block :: block
+        @typep block_struct :: BlockType.t()
 
-      @block_attributes [:block_id, :type, :content, :blocks]
+        @block_attributes [:block_id, :type, :content, :blocks]
 
-      @content_module Module.concat(__MODULE__, Content)
+        @content_module Module.concat(__MODULE__, Content)
 
-      @primary_key {:block_id, :binary_id, autogenerate: false}
+        @primary_key {:block_id, :binary_id, autogenerate: false}
 
-      @derive {Jason.Encoder, only: @block_attributes}
+        @derive {Jason.Encoder, only: @block_attributes}
 
-      embedded_schema do
-        field(:type, :string, null: false)
-        field(:blocks, CKBlocks)
-        embeds_one(:content, @content_module)
+        embedded_schema do
+          field(:type, :string, null: false)
+          field(:blocks, CKBlocks)
+          embeds_one(:content, @content_module)
+        end
+
+        @doc """
+        Given a named BlockType struct and a map of params, creates a changeset
+        and runs validations for the BlockType and BlockType.Content.
+
+        Returns %Ecto.Changeset{}.
+        """
+        @spec changeset(block_struct, map) :: changeset
+        def changeset(block, params) do
+          changeset =
+            struct(__MODULE__)
+            |> cast(params, [:block_id, :type, :blocks])
+            |> cast_embed(:content)
+            |> lift_content_errors()
+            |> validate_blocks(:blocks, is_block: true)
+
+          validate(block, changeset)
+        end
+
+        @spec validate(block_struct, changeset) :: changeset
+        def validate(_block, changeset), do: changeset
+        defoverridable validate: 2
+
+        @doc """
+        Takes a Block map and converts it to a named BlockType struct according
+        to its :type. Generates a :block_id if necessary, and turns `block.content`
+        into a named BlockType.Content module as well.
+        """
+        @spec from_map(block) :: block_struct
+        def from_map(%{type: type, content: content, blocks: blocks} = attrs) do
+          content =
+            content
+            |> attributes_from_params()
+            |> @content_module.from_map()
+
+          struct!(__MODULE__,
+            block_id: Map.get(attrs, :block_id) || Ecto.UUID.generate(),
+            type: type,
+            content: content,
+            blocks: blocks || []
+          )
+        end
       end
+    else
+      quote do
+        use Ecto.Schema
 
-      @doc """
-      Given a named BlockType struct and a map of params, creates a changeset
-      and runs validations for the BlockType and BlockType.Content.
+        import ColonelKurtz.Validation, only: [validate_blocks: 3]
+        import Ecto.Changeset
+        import ColonelKurtz.BlockType
 
-      Returns %Ecto.Changeset{}.
-      """
-      @spec changeset(block_struct, map) :: changeset
-      def changeset(block, params) do
-        changeset =
-          struct(__MODULE__)
-          |> cast(params, [:block_id, :type, :blocks])
-          |> cast_embed(:content)
-          |> lift_content_errors()
-          |> validate_blocks(:blocks, is_block: true)
+        alias ColonelKurtz.Block
+        alias ColonelKurtz.BlockType
+        alias ColonelKurtz.CKBlocks
+        alias ColonelKurtz.EctoHelpers
 
-        validate(block, changeset)
-      end
+        @typep changeset :: Ecto.Changeset.t()
+        @typep block :: block
+        @typep block_struct :: BlockType.t()
 
-      @spec validate(block_struct, changeset) :: changeset
-      def validate(_block, changeset), do: changeset
-      defoverridable validate: 2
+        @block_attributes [:block_id, :type, :content, :blocks]
 
-      @doc """
-      Takes a Block map and converts it to a named BlockType struct according
-      to its :type. Generates a :block_id if necessary, and turns `block.content`
-      into a named BlockType.Content module as well.
-      """
-      @spec from_map(block) :: block_struct
-      def from_map(%{type: type, content: content, blocks: blocks} = attrs) do
-        content =
-          content
-          |> attributes_from_params()
-          |> @content_module.from_map()
+        @primary_key {:block_id, :binary_id, autogenerate: false}
 
-        struct!(__MODULE__,
-          block_id: Map.get(attrs, :block_id) || Ecto.UUID.generate(),
-          type: type,
-          content: content,
-          blocks: blocks || []
-        )
+        @derive {Jason.Encoder, only: @block_attributes}
+
+        embedded_schema do
+          field(:type, :string, null: false)
+          field(:blocks, CKBlocks)
+          field(:content, :map)
+        end
+
+        @doc """
+        Given a named BlockType struct and a map of params, creates a changeset
+        and runs validations for the BlockType and BlockType.Content.
+
+        Returns %Ecto.Changeset{}.
+        """
+        @spec changeset(block_struct, map) :: changeset
+        def changeset(block, params) do
+          changeset =
+            struct(__MODULE__)
+            |> cast(params, [:block_id, :type, :blocks, :content])
+            |> validate_blocks(:blocks, is_block: true)
+
+          validate(block, changeset)
+        end
+
+        @spec validate(block_struct, changeset) :: changeset
+        def validate(_block, changeset), do: changeset
+        defoverridable validate: 2
+
+        @doc """
+        Takes a Block map and converts it to a named BlockType struct according
+        to its :type. Generates a :block_id if necessary, and turns `block.content`
+        into a named BlockType.Content module as well.
+        """
+        @spec from_map(block) :: block_struct
+        def from_map(%{type: type, content: content, blocks: blocks} = attrs) do
+          struct!(__MODULE__,
+            block_id: Map.get(attrs, :block_id) || Ecto.UUID.generate(),
+            type: type,
+            content: attributes_from_params(content),
+            blocks: blocks || []
+          )
+        end
       end
     end
   end

--- a/lib/colonel_kurtz/block_type/with_content.ex
+++ b/lib/colonel_kurtz/block_type/with_content.ex
@@ -1,0 +1,75 @@
+# See `lib/colonel_kurtz/block_type.ex` __using__
+# This defines a BlockType module that has a child Content module
+
+quote do
+  use Ecto.Schema
+
+  import ColonelKurtz.Validation, only: [validate_blocks: 3]
+  import Ecto.Changeset
+  import ColonelKurtz.BlockType
+
+  alias ColonelKurtz.Block
+  alias ColonelKurtz.BlockType
+  alias ColonelKurtz.CKBlocks
+  alias ColonelKurtz.EctoHelpers
+
+  @typep changeset :: Ecto.Changeset.t()
+  @typep block :: block
+  @typep block_struct :: BlockType.t()
+
+  @block_attributes [:block_id, :type, :content, :blocks]
+
+  @content_module Module.concat(__MODULE__, Content)
+
+  @primary_key {:block_id, :binary_id, autogenerate: false}
+
+  @derive {Jason.Encoder, only: @block_attributes}
+
+  embedded_schema do
+    field(:type, :string, null: false)
+    field(:blocks, CKBlocks)
+    embeds_one(:content, @content_module)
+  end
+
+  @doc """
+  Given a named BlockType struct and a map of params, creates a changeset
+  and runs validations for the BlockType and BlockType.Content.
+
+  Returns %Ecto.Changeset{}.
+  """
+  @spec changeset(block_struct, map) :: changeset
+  def changeset(block, params) do
+    changeset =
+      struct(__MODULE__)
+      |> cast(params, [:block_id, :type, :blocks])
+      |> cast_embed(:content)
+      |> lift_content_errors()
+      |> validate_blocks(:blocks, is_block: true)
+
+    validate(block, changeset)
+  end
+
+  @spec validate(block_struct, changeset) :: changeset
+  def validate(_block, changeset), do: changeset
+  defoverridable validate: 2
+
+  @doc """
+  Takes a Block map and converts it to a named BlockType struct according
+  to its :type. Generates a :block_id if necessary, and turns `block.content`
+  into a named BlockType.Content module as well.
+  """
+  @spec from_map(block) :: block_struct
+  def from_map(%{type: type, content: content, blocks: blocks} = attrs) do
+    content =
+      content
+      |> attributes_from_params()
+      |> @content_module.from_map()
+
+    struct!(__MODULE__,
+      block_id: Map.get(attrs, :block_id) || Ecto.UUID.generate(),
+      type: type,
+      content: content,
+      blocks: blocks || []
+    )
+  end
+end

--- a/lib/colonel_kurtz/block_type/without_content.ex
+++ b/lib/colonel_kurtz/block_type/without_content.ex
@@ -1,0 +1,67 @@
+# See `lib/colonel_kurtz/block_type.ex` __using__
+# This is used when a Block is defined without a Content module,
+# i.e. a block that is only concerned with its child blocks
+
+quote do
+  use Ecto.Schema
+
+  import ColonelKurtz.Validation, only: [validate_blocks: 3]
+  import Ecto.Changeset
+  import ColonelKurtz.BlockType
+
+  alias ColonelKurtz.Block
+  alias ColonelKurtz.BlockType
+  alias ColonelKurtz.CKBlocks
+  alias ColonelKurtz.EctoHelpers
+
+  @typep changeset :: Ecto.Changeset.t()
+  @typep block :: block
+  @typep block_struct :: BlockType.t()
+
+  @block_attributes [:block_id, :type, :content, :blocks]
+
+  @primary_key {:block_id, :binary_id, autogenerate: false}
+
+  @derive {Jason.Encoder, only: @block_attributes}
+
+  embedded_schema do
+    field(:type, :string, null: false)
+    field(:blocks, CKBlocks)
+    field(:content, :map)
+  end
+
+  @doc """
+  Given a named BlockType struct and a map of params, creates a changeset
+  and runs validations for the BlockType and BlockType.Content.
+
+  Returns %Ecto.Changeset{}.
+  """
+  @spec changeset(block_struct, map) :: changeset
+  def changeset(block, params) do
+    changeset =
+      struct(__MODULE__)
+      |> cast(params, [:block_id, :type, :blocks, :content])
+      |> validate_blocks(:blocks, is_block: true)
+
+    validate(block, changeset)
+  end
+
+  @spec validate(block_struct, changeset) :: changeset
+  def validate(_block, changeset), do: changeset
+  defoverridable validate: 2
+
+  @doc """
+  Takes a Block map and converts it to a named BlockType struct according
+  to its :type. Generates a :block_id if necessary, and turns `block.content`
+  into a named BlockType.Content module as well.
+  """
+  @spec from_map(block) :: block_struct
+  def from_map(%{type: type, content: content, blocks: blocks} = attrs) do
+    struct!(__MODULE__,
+      block_id: Map.get(attrs, :block_id) || Ecto.UUID.generate(),
+      type: type,
+      content: attributes_from_params(content),
+      blocks: blocks || []
+    )
+  end
+end

--- a/test/block_type_test.exs
+++ b/test/block_type_test.exs
@@ -7,6 +7,7 @@ defmodule ColonelKurtzTest.BlockTypeTest do
   doctest ColonelKurtz.BlockType
 
   alias ColonelKurtzTest.BlockTypes.ExampleBlock
+  alias ColonelKurtzTest.BlockTypes.SectionBlock
 
   describe "BlockType" do
     test "example" do
@@ -20,6 +21,16 @@ defmodule ColonelKurtzTest.BlockTypeTest do
       block = build_block_type(ExampleBlock, type: "example", content: %{text: ""})
 
       assert %{valid?: false} = ExampleBlock.changeset(block, Map.from_struct(block))
+    end
+
+    test "renders a block with `content: false`" do
+      example_block = build_block_type(ExampleBlock, type: "example", content: %{text: "Example"})
+      section_block = build_block_type(SectionBlock, type: "section", blocks: [example_block])
+
+      assert %SectionBlock{} = section_block
+
+      assert %{valid?: true} =
+               SectionBlock.changeset(section_block, Map.from_struct(section_block))
     end
   end
 

--- a/test/support/block_types/section.ex
+++ b/test/support/block_types/section.ex
@@ -1,0 +1,9 @@
+defmodule ColonelKurtzTest.BlockTypes.SectionBlock do
+  @moduledoc false
+  use ColonelKurtz.BlockType, content: false
+
+  def validate(_block, changeset) do
+    changeset
+    |> validate_length(:blocks, min: 1)
+  end
+end


### PR DESCRIPTION
Resolves #16 

This allows users to define Blocks without defining a `Content` module, by passing a flag like so: `use ColonelKurtz.BlockType, content: false`.

I was unable to generate a blank Content module in the way we can do for BlockTypes when a user defines their own Content module due to a funky compile-time chicken / egg problem this creates. The approach of adding a new flag works, and this is a pretty rare use case anyways.